### PR TITLE
fix facebook login fix #14

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,12 +1,12 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
     @user = User.from_omniauth(request.env["omniauth.auth"])
-
     if @user.persisted?
-      sign_in_and_redirect user_root_path
+      sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "Facebook") if is_navigational_format?
     else
       session["devise.user_attributes"] = @user.attributes
+      flash[:notice] = "facebook認証が完了しました。会員登録をしてください"
       redirect_to new_user_registration_url
     end
   end
@@ -15,10 +15,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
-      sign_in_and_redirect user_root_path
+      sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "Twitter") if is_navigational_format?
     else
       session["devise.user_attributes"] = @user.attributes
+      flash[:notice] = "Twitter認証が完了しました。会員登録をしてください"
       redirect_to new_user_registration_url
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: [:facebook, :twitter]
-  has_many :posts;
+  has_many :posts
   mount_uploader :avatar, AvatarUploader
 
   def self.from_omniauth(auth)
@@ -49,7 +49,7 @@ class User < ApplicationRecord
       user.uid = auth["uid"]
       user.username = auth["info"]["nickname"]
       user.provider  = auth["provider"]
-      # user.email = auth["info"]["email"]
+      user.email = auth["info"]["email"]
       # user.password = Devise.friendly_token[0, 20]
       # user.image = auth.info.image # assuming the user model has an image
       # If you are using confirmable and the provider(s) you use validate emails,

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -5,6 +5,8 @@
       | 会員登録
 
     = form_for resource, as: resource_name, url: registration_path(resource_name) do |f|
+      = render "devise/shared/error_messages", resource: resource
+
       .form-group
         = f.label :username, "ユーザネーム"
         = f.text_field :username, autocomplete: "username", class:"form-control"


### PR DESCRIPTION
edit: 変更点
------------------------------------

facebook　SNS認証を修正
＊バグだと判断した理由
sign in を押下したあとに会員登録の各フォームにfbから連携された情報が追加されない

＊バグの原因
SNSへの遷移はできていたが、確認ができない状態だった。
fbからの情報はアプリには連携されていたが、フォームに入力されない状態だった

＊修正項目
・SNS認証が成功した際にflashメッセージで
　「認証に成功しました。会員登録をしてください」と出るようにする
・modelでSNSから連携されたemailを取得できるようにした
